### PR TITLE
DFA in Julia

### DIFF
--- a/Julia/dfa.jl
+++ b/Julia/dfa.jl
@@ -1,0 +1,128 @@
+"""
+A "type" to indicate a state of an automaton
+"""
+State = String
+
+
+"""
+An automaton having:
+ - A set of start states q₀
+ - A set of final/accepting states F
+ - A set of input symbols (alphabet) Σ
+ - A set of states Q
+ - A transition function δ
+
+Notations are from Wikipedia:
+https://en.wikipedia.org/wiki/Deterministic_finite_automaton
+"""
+struct Automaton
+    q₀::Set{State}
+    F::Set{State}
+    Σ::Set{Char}
+    Q::Set{State}
+    δ::Dict{Tuple{State,Char},State}
+end
+
+Automaton(Σ::String, F, δ) = Automaton(collect(Σ), F, δ)
+
+
+function Automaton(δ::Dict{Tuple{State,Char},State},
+        q₀::Set{State},
+                  F::Set{State})
+    # infer alphabet from transitions
+    Σ = Set{Char}()
+
+    # Q will be set of all states
+    Q = Set{State}()
+    # reached will be set of destination states
+    reached = Set{State}()
+    for (k, v) in δ
+        # destination state
+        d_state = State(v)
+        push!(Q, d_state)
+
+        # non-final source state
+        s_state = State(k[1])
+        push!(Q, s_state)
+
+        push!(Σ, k[2])  # add to alphabet
+    end
+
+    Automaton(q₀, F, Σ, Q, δ)
+end
+
+"""
+A Deterministic Finite Automaton (DFA)
+
+Has only 3 components
+ - the current state the DFA is in
+ - the start state (same as `.aut.q₀`)
+ - all other components are encapsulated in Automaton
+   since they are static and need not have to be mutable
+"""
+mutable struct DFA
+    cur_state::State
+    q₀::State
+    aut::Automaton
+end
+
+function DFA(aut::Automaton)
+    q₀ = collect(aut.q₀)[1]
+    DFA(q₀, q₀, aut)
+end
+
+DFA(δ::Dict{Tuple{State,Char},State},
+    q₀::State,
+    F::Set{State}) = DFA(Automaton(δ, Set([q₀]), F))
+
+
+"""
+    transition!(dfa::DFA, char::Char)::Bool
+
+Applies a transition from current state using the symbol
+char. Returns `false` when transition fails (Note: does
+not throw an exception for performance reasons) and true
+when the transition succeeds while updating the current
+state of the DFA.
+"""
+function transition!(M::DFA, a::Char)::Bool
+    key = (M.cur_state, a)
+
+    if !haskey(M.aut.δ, key)
+        return false
+    end
+
+    M.cur_state = M.aut.δ[key]
+    return true
+end
+
+
+"""
+    reset!(dfa::DFA)
+
+Resets the DFA to it's start state.
+"""
+function reset!(M::DFA)
+    M.cur_state = M.q₀
+end
+
+
+"""
+    evaluate!(M::DFA, w::String)
+
+Evaluates the input string using the DFA.
+The DFA is reset before evaluating.
+
+Returns `true` if string is accepted and
+`false` otherwise. The final state is stored
+in `M.cur_state`
+"""
+function evaluate!(M::DFA, w::String)
+    reset!(M)
+
+    for a in w
+        transition!(M, a) || return false
+    end
+
+    M.cur_state ∈ M.aut.F ? true : false
+end

--- a/Julia/test.jl
+++ b/Julia/test.jl
@@ -1,0 +1,21 @@
+using Test
+
+include("dfa.jl")
+
+M = DFA(Dict(
+         ("q0", 'a') => "q1",
+         ("q0", 'b') => "q0",
+         ("q1", 'a') => "q2",
+         ("q1", 'b') => "q1",
+         ("q2", 'a') => "q3",
+         ("q2", 'b') => "q2",
+         ("q3", 'a') => "q4",
+         ("q3", 'b') => "q3",
+         ("q4", 'a') => "q4",
+         ("q4", 'b') => "q4"
+       ), "q0", Set(["q0", "q1", "q2", "q3"]))
+
+@test evaluate!(M, "")
+@test evaluate!(M, "aaab")
+@test evaluate!(M, "bbbb")
+@test !evaluate!(M, "aaaab")

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Languages implemented in so far:
 - JavaScript
 - C++
 - Go
+- Julia
 - Racket
 - Haskell (NFA evaluator included)
 - Nim


### PR DESCRIPTION
# Description

DFA simulator implemented in Julia

# Usage

A DFA can be "instantiated" using just the transition function (as a `Dict`), the start state and the set of final states.

```julia
M = DFA(Dict(
         ("q0", 'a') => "q1",
         ("q0", 'b') => "q0",
         ("q1", 'a') => "q2",
         ("q1", 'b') => "q1",
         ("q2", 'a') => "q3",
         ("q2", 'b') => "q2",
         ("q3", 'a') => "q4",
         ("q3", 'b') => "q3",
         ("q4", 'a') => "q4",
         ("q4", 'b') => "q4"
       ), "q0", Set(["q0", "q1", "q2", "q3"]))
```

A string can be evaluated using:
```julia
evaluate!(M, "aaab")  # returns true
```

# Performance

I did some basic testing for performance using the above DFA (10 transitions, 5 states) and a string consisting of `a`s.

```julia
julia> @btime evaluate!($M, "a"^1)
  135.740 ns (0 allocations: 0 bytes)
true

julia> @btime evaluate!($M, "a"^10)
  959.273 ns (1 allocation: 32 bytes)
false

julia> @btime evaluate!($M, "a"^100)
  7.863 μs (1 allocation: 128 bytes)
false

julia> @btime evaluate!($M, "a"^1000)
  73.445 μs (1 allocation: 1.06 KiB)
false

julia> @btime evaluate!($M, "a"^10000)
  735.670 μs (1 allocation: 9.88 KiB)
false

julia> @btime evaluate!($M, "a"^100000)
  5.823 ms (1 allocation: 97.75 KiB)
false

julia> @btime evaluate!($M, "a"^1000000)
  58.482 ms (1 allocation: 976.69 KiB)
false
```

Even a string with 1 million symbols was evaluated in ~50ms! :exploding_head: 

(the allocations are only for the input string, there are no allocations performed during evaluation)